### PR TITLE
Feature/헤더 공통 컴포넌트 구현

### DIFF
--- a/src/Layout/BaseLayout.tsx
+++ b/src/Layout/BaseLayout.tsx
@@ -1,19 +1,19 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
+import { Header } from '@/components/common/Header';
 
 type Props = {
   maxWidth?: number;
-  header?: ReactNode;
   children: ReactNode;
 };
 
-export const BaseLayout = ({ maxWidth = 720, header, children }: Props) => {
+export const BaseLayout = ({ maxWidth = 720, children }: Props) => {
   return (
     <Wrapper>
-      {header && <FixedHeader maxWidth={maxWidth}>{header}</FixedHeader>}
-      <Container maxWidth={maxWidth} hasHeader={!!header}>
-        {children}
-      </Container>
+      <FixedHeader maxWidth={maxWidth}>
+        <Header />
+      </FixedHeader>
+      <Container maxWidth={maxWidth}>{children}</Container>
     </Wrapper>
   );
 };
@@ -30,7 +30,6 @@ const Wrapper = styled.div(({ theme }) => ({
 }));
 
 const FixedHeader = styled.div<{ maxWidth: number }>(({ maxWidth }) => ({
-  position: 'fixed',
   top: 0,
   left: 0,
   right: 0,

--- a/src/Layout/BaseLayout.tsx
+++ b/src/Layout/BaseLayout.tsx
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 import type { ReactNode } from 'react';
 import { Header } from '@/components/common/Header';
+import useHeaderStore from '@/stores/useHeaderStore';
 
 type Props = {
   maxWidth?: number;
@@ -8,12 +9,19 @@ type Props = {
 };
 
 export const BaseLayout = ({ maxWidth = 720, children }: Props) => {
+  const { left, center, right } = useHeaderStore();
+  const hasHeader = !!(left || center || right);
+
   return (
     <Wrapper>
-      <FixedHeader maxWidth={maxWidth}>
-        <Header />
-      </FixedHeader>
-      <Container maxWidth={maxWidth}>{children}</Container>
+      {hasHeader && (
+        <FixedHeader maxWidth={maxWidth}>
+          <Header />
+        </FixedHeader>
+      )}
+      <Container maxWidth={maxWidth} hasHeader={hasHeader}>
+        {children}
+      </Container>
     </Wrapper>
   );
 };
@@ -37,6 +45,7 @@ const FixedHeader = styled.div<{ maxWidth: number }>(({ maxWidth }) => ({
   maxWidth: `${maxWidth}px`,
   width: '100%',
   zIndex: 1000,
+  position: 'fixed',
 }));
 
 type ContainerProps = {

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,15 +1,22 @@
 import { typography } from '@/styles/typography';
 import styled from '@emotion/styled';
 import useHeaderStore from '@/stores/useHeaderStore';
+import { HiOutlineChevronLeft } from 'react-icons/hi';
+import { useNavigate } from 'react-router-dom';
 
 export const Header = () => {
   const { left, center, right } = useHeaderStore();
+  const navigate = useNavigate();
+
+  const defaultLeft = (
+    <HiOutlineChevronLeft size={20} style={{ cursor: 'pointer' }} onClick={() => navigate(-1)} />
+  );
 
   if (!left && !center && !right) return null;
 
   return (
     <Wrapper>
-      <Section>{left}</Section>
+      <Section>{left ?? defaultLeft}</Section>
       <CenterSection>{center}</CenterSection>
       <Section>{right}</Section>
     </Wrapper>

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,46 @@
+import { typography } from '@/styles/typography';
+import styled from '@emotion/styled';
+import useHeaderStore from '@/stores/useHeaderStore';
+
+export const Header = () => {
+  const { left, center, right } = useHeaderStore();
+
+  if (!left && !center && !right) return null;
+
+  return (
+    <Wrapper>
+      <Section>{left}</Section>
+      <CenterSection>{center}</CenterSection>
+      <Section>{right}</Section>
+    </Wrapper>
+  );
+};
+
+const Wrapper = styled.header(({ theme }) => ({
+  height: '2.75rem',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  backgroundColor: theme.colors.white,
+  borderBottom: `1px solid ${theme.colors.gray200}`,
+  padding: `0 ${theme.spacing.spacing4}px`,
+}));
+
+const Section = styled.div({
+  display: 'flex',
+  alignItems: 'center',
+  minWidth: '2.5rem',
+  justifyContent: 'flex-start',
+  '&:last-of-type': {
+    justifyContent: 'flex-end',
+  },
+});
+
+const CenterSection = styled.div({
+  flexGrow: 1,
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  textAlign: 'center',
+  ...typography.h3,
+});

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -14,9 +14,11 @@ export const Header = () => {
 
   if (!left && !center && !right) return null;
 
+  const leftNode = left === null ? null : (left ?? defaultLeft);
+
   return (
     <Wrapper>
-      <Section>{left ?? defaultLeft}</Section>
+      <Section>{leftNode}</Section>
       <CenterSection>{center}</CenterSection>
       <Section>{right}</Section>
     </Wrapper>

--- a/src/hooks/useHeader.tsx
+++ b/src/hooks/useHeader.tsx
@@ -3,20 +3,15 @@ import useHeaderStore from '@/stores/useHeaderStore';
 import type { ReactNode } from 'react';
 
 type HeaderContent = {
-  left?: ReactNode;
+  left?: ReactNode | null;
   center?: string | null;
-  right?: ReactNode;
+  right?: ReactNode | null;
 };
 
 export const useHeader = ({ left, center, right }: HeaderContent) => {
   const { setHeader, resetHeader } = useHeaderStore.getState();
-
   useEffect(() => {
-    setHeader({
-      left: left ?? null,
-      center: center ?? null,
-      right: right ?? null,
-    });
+    setHeader({ left, center, right });
 
     return () => {
       resetHeader();

--- a/src/hooks/useHeader.tsx
+++ b/src/hooks/useHeader.tsx
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import useHeaderStore from '@/stores/useHeaderStore';
+import type { ReactNode } from 'react';
+
+type HeaderContent = {
+  left?: ReactNode;
+  center?: string | null;
+  right?: ReactNode;
+};
+
+export const useHeader = ({ left, center, right }: HeaderContent) => {
+  const { setHeader, resetHeader } = useHeaderStore.getState();
+
+  useEffect(() => {
+    setHeader({
+      left: left ?? null,
+      center: center ?? null,
+      right: right ?? null,
+    });
+
+    return () => {
+      resetHeader();
+    };
+  }, [left, center, right, setHeader, resetHeader]);
+};

--- a/src/stores/useHeaderStore.ts
+++ b/src/stores/useHeaderStore.ts
@@ -8,7 +8,7 @@ interface IHeaderState {
 }
 
 interface IHeaderActions {
-  setHeader: (content: Partial<IHeaderState>) => void;
+  setHeader: (content: IHeaderState) => void;
   resetHeader: () => void;
 }
 
@@ -16,7 +16,7 @@ type IHeaderStore = IHeaderState & IHeaderActions;
 
 const useHeaderStore = create<IHeaderStore>((set) => {
   const resetHeader = () => set({ left: null, center: null, right: null });
-  const setHeader = (content: Partial<IHeaderState>) => set((state) => ({ ...state, ...content }));
+  const setHeader = (content: IHeaderState) => set(content);
 
   return {
     left: null,

--- a/src/stores/useHeaderStore.ts
+++ b/src/stores/useHeaderStore.ts
@@ -2,29 +2,30 @@ import { create } from 'zustand';
 import type { ReactNode } from 'react';
 
 interface IHeaderState {
-  left: ReactNode | null;
-  center: string | null;
-  right: ReactNode | null;
+  left: ReactNode | null | undefined;
+  center: string | null | undefined;
+  right: ReactNode | null | undefined;
 }
 
 interface IHeaderActions {
-  setHeader: (content: IHeaderState) => void;
+  setHeader: (content: {
+    left?: ReactNode | null;
+    center?: string | null;
+    right?: ReactNode | null;
+  }) => void;
   resetHeader: () => void;
 }
 
 type IHeaderStore = IHeaderState & IHeaderActions;
 
-const useHeaderStore = create<IHeaderStore>((set) => {
-  const resetHeader = () => set({ left: null, center: null, right: null });
-  const setHeader = (content: IHeaderState) => set(content);
+const useHeaderStore = create<IHeaderStore>((set) => ({
+  left: undefined,
+  center: undefined,
+  right: undefined,
 
-  return {
-    left: null,
-    center: null,
-    right: null,
-    setHeader,
-    resetHeader,
-  };
-});
+  setHeader: (content) => set(content),
+
+  resetHeader: () => set({ left: undefined, center: undefined, right: undefined }),
+}));
 
 export default useHeaderStore;

--- a/src/stores/useHeaderStore.ts
+++ b/src/stores/useHeaderStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import type { ReactNode } from 'react';
+
+interface IHeaderState {
+  left: ReactNode | null;
+  center: string | null;
+  right: ReactNode | null;
+}
+
+interface IHeaderActions {
+  setHeader: (content: Partial<IHeaderState>) => void;
+  resetHeader: () => void;
+}
+
+type IHeaderStore = IHeaderState & IHeaderActions;
+
+const useHeaderStore = create<IHeaderStore>((set) => {
+  const resetHeader = () => set({ left: null, center: null, right: null });
+  const setHeader = (content: Partial<IHeaderState>) => set((state) => ({ ...state, ...content }));
+
+  return {
+    left: null,
+    center: null,
+    right: null,
+    setHeader,
+    resetHeader,
+  };
+});
+
+export default useHeaderStore;


### PR DESCRIPTION
## 주요 변경사항
헤더 공통 컴포넌트를 구현했습니다.

useHeader 커스텀 훅을 사용해 페이지 단에서 Header 제어
각 페이지 컴포넌트에서 아래처럼 호출하면 됩니다!!
```
useHeader({
    left: (
      <HiOutlineChevronLeft
        size={20}
        style={{ cursor: 'pointer' }}
        onClick={() => window.history.back()}
      />
    ),
    center: '타이틀 이름',
    right: null,
  });
```

## 리뷰어에게...
- Zustand를 이용해 전역 Header 상태 관리 기능 추가했습니다
- Header 컴포넌트가 useHeaderStore를 직접 구독하도록 구현했습니다.

## 관련 이슈
#32 

