### PR TITLE
Feature/신고모달

### DIFF
--- a/src/Layout/BaseLayout.tsx
+++ b/src/Layout/BaseLayout.tsx
@@ -52,11 +52,12 @@ type ContainerProps = {
   maxWidth?: number;
   hasHeader?: boolean;
 };
-const Container = styled.div<ContainerProps>(({ maxWidth, hasHeader, theme }) => ({
+const Container = styled.main<ContainerProps>(({ maxWidth, hasHeader, theme }) => ({
   maxWidth: `${maxWidth}px`,
   width: '100%',
   minHeight: '100vh',
-  height: '100%',
   backgroundColor: theme.colors.white,
-  paddingTop: hasHeader ? '2.75rem' : '0',
+  paddingTop: hasHeader ? '3rem' : '0',
+  position: 'relative',
+  margin: '0 auto',
 }));

--- a/src/api/reportApi.ts
+++ b/src/api/reportApi.ts
@@ -1,0 +1,32 @@
+import axios from 'axios';
+
+export type TargetType = 'USER' | 'GROUP' | 'POST' | 'COMMENT';
+
+export interface ReportRequest {
+  reasonCode: string;
+  reason: string;
+}
+
+export interface ReportResponse {
+  id: number;
+  reporterId: number;
+  targetType: TargetType;
+  targetId: number;
+  reasonCode: string;
+  reason: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const createReport = async (
+  targetType: TargetType,
+  targetId: number,
+  payload: ReportRequest
+): Promise<ReportResponse> => {
+  const { data } = await axios.post<ReportResponse>(
+    `/api/reports/${targetType}/${targetId}`,
+    payload
+  );
+  return data;
+};

--- a/src/components/ReportModal.tsx
+++ b/src/components/ReportModal.tsx
@@ -42,7 +42,11 @@ const ReportModal = ({ isOpen, onClose, targetId, targetType }: ReportModalProps
     formState: { errors },
   } = useForm<ReportForm>({
     defaultValues: { reason: '', detail: '' },
+    mode: 'onChange',
+    reValidateMode: 'onChange',
   });
+
+  const errorMessage = errors.reason?.message || errors.detail?.message || '';
 
   useEffect(() => {
     if (!isOpen) {
@@ -101,7 +105,7 @@ const ReportModal = ({ isOpen, onClose, targetId, targetType }: ReportModalProps
             },
           })}
         />
-        {errors.reason && <ErrorMessage>{errors.reason.message}</ErrorMessage>}
+        {errorMessage && <ErrorMessage>{errorMessage}</ErrorMessage>}
 
         <Bottom>
           <TextLength currentLength={detail.length} maxLength={MAX_LENGTH} />

--- a/src/components/ReportModal.tsx
+++ b/src/components/ReportModal.tsx
@@ -1,0 +1,211 @@
+import styled from '@emotion/styled';
+import BaseModal from '@/components/common/BaseModal';
+import { colors } from '@/styles/colors';
+import { spacing } from '@/styles/spacing';
+import { typography } from '@/styles/typography';
+import TextLength from './common/TextLength';
+import { useForm, Controller } from 'react-hook-form';
+import { useReport } from '@/hooks/useReport';
+import { useEffect } from 'react';
+
+interface ReportModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  targetType: 'USER' | 'GROUP' | 'POST' | 'COMMENT';
+  targetId: number;
+}
+
+interface ReportForm {
+  reason: string;
+  detail: string;
+}
+
+const REPORT_REASONS = [
+  { code: 'RELIGION_SUSPECT', label: '종교 의심됨' },
+  { code: 'NOT_HEALTHY_PURPOSE', label: '건전한 목적이 아님' },
+  { code: 'INAPPROPRIATE', label: '불쾌한 내용' },
+  { code: 'FRAUD_OR_PRIVACY', label: '사기·개인정보 요구' },
+  { code: 'OTHER', label: '기타' },
+];
+
+const MAX_LENGTH = 500;
+
+const ReportModal = ({ isOpen, onClose, targetId, targetType }: ReportModalProps) => {
+  const { mutate } = useReport(targetType, targetId);
+
+  const {
+    register,
+    control,
+    handleSubmit,
+    watch,
+    reset,
+    formState: { errors },
+  } = useForm<ReportForm>({
+    defaultValues: { reason: '', detail: '' },
+  });
+
+  useEffect(() => {
+    if (!isOpen) {
+      reset();
+    }
+  }, [isOpen, reset]);
+
+  const detail = watch('detail');
+
+  const submitHandler = (data: ReportForm) => {
+    mutate(
+      { reasonCode: data.reason, reason: data.detail },
+      {
+        onSuccess: () => {
+          alert('신고가 접수되었습니다.');
+          onClose();
+        },
+        onError: () => {
+          alert('신고 처리 중 오류가 발생했습니다.');
+        },
+      }
+    );
+  };
+
+  return (
+    <BaseModal isOpen={isOpen} onClose={onClose} variant="center" maxWidth={320}>
+      <Title>신고하기</Title>
+
+      <form onSubmit={handleSubmit(submitHandler)}>
+        <ReasonList>
+          {REPORT_REASONS.map(({ code, label }) => (
+            <ReasonItem key={code}>
+              <Controller
+                name="reason"
+                control={control}
+                rules={{ required: '신고 사유를 선택해주세요.' }}
+                render={({ field }) => (
+                  <CustomCheckbox
+                    type="checkbox"
+                    checked={field.value === code}
+                    onChange={() => field.onChange(field.value === code ? '' : code)}
+                  />
+                )}
+              />
+              <span>{label}</span>
+            </ReasonItem>
+          ))}
+        </ReasonList>
+
+        <DetailTextarea
+          placeholder="신고사유를 적어주세요."
+          {...register('detail', {
+            maxLength: {
+              value: MAX_LENGTH,
+              message: `최대 ${MAX_LENGTH}자까지 입력 가능합니다.`,
+            },
+          })}
+        />
+        {errors.reason && <ErrorMessage>{errors.reason.message}</ErrorMessage>}
+
+        <Bottom>
+          <TextLength currentLength={detail.length} maxLength={MAX_LENGTH} />
+        </Bottom>
+
+        <ButtonGroup>
+          <CancelButton type="button" onClick={onClose}>
+            취소하기
+          </CancelButton>
+          <SubmitButton type="submit">신고하기</SubmitButton>
+        </ButtonGroup>
+      </form>
+    </BaseModal>
+  );
+};
+
+export default ReportModal;
+
+const Title = styled.h2({
+  ...typography.h2,
+  marginBottom: spacing.spacing3,
+  textAlign: 'center',
+});
+
+const ReasonList = styled.div({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: spacing.spacing2,
+  marginBottom: spacing.spacing3,
+});
+
+const ReasonItem = styled.label({
+  display: 'flex',
+  alignItems: 'center',
+  gap: spacing.spacing2,
+  ...typography.body,
+});
+
+const CustomCheckbox = styled.input({
+  appearance: 'none',
+  width: '18px',
+  height: '18px',
+  border: `1px solid ${colors.gray400}`,
+  borderRadius: '4px',
+  cursor: 'pointer',
+  '&:checked': {
+    backgroundColor: colors.primary,
+    borderColor: colors.primary,
+  },
+});
+
+const DetailTextarea = styled.textarea({
+  ...typography.body,
+  fontFamily: typography.fontFamily,
+  width: '100%',
+  maxWidth: '100%',
+  minHeight: '136px',
+  padding: spacing.spacing2,
+  border: `1px solid ${colors.gray300}`,
+  borderRadius: '8px',
+  resize: 'none',
+  boxSizing: 'border-box',
+  backgroundColor: colors.backgroundGray,
+  outline: 'none',
+  '&:focus': {
+    borderColor: colors.primary,
+  },
+  marginBottom: spacing.spacing1,
+});
+
+const Bottom = styled.div({
+  display: 'flex',
+});
+
+const ErrorMessage = styled.span({
+  ...typography.caption,
+  color: colors.error,
+  marginLeft: spacing.spacing1,
+});
+
+const ButtonGroup = styled.div({
+  display: 'flex',
+  gap: spacing.spacing2,
+  marginTop: spacing.spacing2,
+});
+
+const CancelButton = styled.button({
+  flex: 1,
+  padding: spacing.spacing3,
+  borderRadius: '8px',
+  border: `1px solid ${colors.gray300}`,
+  backgroundColor: colors.white,
+  cursor: 'pointer',
+  ...typography.body,
+});
+
+const SubmitButton = styled.button({
+  flex: 1,
+  padding: spacing.spacing3,
+  borderRadius: '8px',
+  border: 'none',
+  backgroundColor: colors.primary,
+  color: colors.white,
+  cursor: 'pointer',
+  ...typography.body,
+  fontWeight: 600,
+});

--- a/src/components/common/BaseModal.tsx
+++ b/src/components/common/BaseModal.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from 'react';
+import styled from '@emotion/styled';
+import { spacing } from '@/styles/spacing';
+import { colors } from '@/styles/colors';
+import { keyframes } from '@emotion/react';
+
+type ModalVariant = 'center' | 'bottom';
+
+interface BaseModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  children: ReactNode;
+  variant?: ModalVariant;
+  maxWidth?: number;
+}
+
+const BaseModal = ({
+  isOpen,
+  onClose,
+  children,
+  variant = 'center',
+  maxWidth = 480,
+}: BaseModalProps) => {
+  if (!isOpen) return null;
+
+  return (
+    <Overlay onClick={onClose}>
+      <Content variant={variant} maxWidth={maxWidth} onClick={(e) => e.stopPropagation()}>
+        <Inner>{children}</Inner>
+      </Content>
+    </Overlay>
+  );
+};
+
+export default BaseModal;
+
+const slideUp = keyframes({
+  from: { transform: 'translateX(-50%) translateY(100%)' },
+  to: { transform: 'translateX(-50%) translateY(0)' },
+});
+
+const fadeIn = keyframes({
+  from: { opacity: 0, transform: 'scale(0.95)' },
+  to: { opacity: 1, transform: 'scale(1)' },
+});
+
+const Overlay = styled.div({
+  position: 'absolute',
+  inset: 0,
+  background: 'rgba(0,0,0,0.4)',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+  zIndex: 2000,
+});
+
+const Content = styled.div<{ variant: ModalVariant; maxWidth: number }>(
+  ({ variant, maxWidth }) => ({
+    background: colors.white,
+    borderRadius: variant === 'bottom' ? '12px 12px 0 0' : '8px',
+    width: '100%',
+    maxWidth: variant === 'bottom' ? '720px' : `${maxWidth}px`,
+    animation: variant === 'bottom' ? `${slideUp} 0.3s ease` : `${fadeIn} 0.2s ease`,
+    ...(variant === 'bottom'
+      ? {
+          position: 'absolute',
+          bottom: 0,
+          left: '50%',
+          transform: 'translateX(-50%)',
+        }
+      : {
+          margin: '0 auto',
+        }),
+  })
+);
+
+const Inner = styled.div({
+  padding: spacing.spacing4,
+  boxSizing: 'border-box',
+  width: '100%',
+});

--- a/src/hooks/useReport.ts
+++ b/src/hooks/useReport.ts
@@ -1,0 +1,9 @@
+import { useMutation } from '@tanstack/react-query';
+import type { ReportRequest, ReportResponse, TargetType } from '@/api/reportApi';
+import { createReport } from '@/api/reportApi';
+
+export const useReport = (targetType: TargetType, targetId: number) => {
+  return useMutation<ReportResponse, Error, ReportRequest>({
+    mutationFn: (payload) => createReport(targetType, targetId, payload),
+  });
+};

--- a/src/pages/DemoPage.tsx
+++ b/src/pages/DemoPage.tsx
@@ -1,0 +1,38 @@
+import { useState } from 'react';
+import BaseModal from '@/components/common/BaseModal';
+import styled from '@emotion/styled';
+import ReportModal from '@/components/ReportModal';
+import { useHeader } from '@/hooks/useHeader';
+
+export default function DemoPage() {
+  const [isModalOpen, setModalOpen] = useState(false);
+  const [isSheetOpen, setSheetOpen] = useState(false);
+
+  useHeader({ leftContent: null, centerContent: '테스트페이지' });
+
+  return (
+    <div>
+      <button onClick={() => setModalOpen(true)}>중앙 모달 열기</button>
+      <button onClick={() => setSheetOpen(true)}>바텀시트 열기</button>
+
+      <ReportModal
+        isOpen={isModalOpen}
+        onClose={() => setModalOpen(false)}
+        targetType="GROUP"
+        targetId={1} //임시로 넣음
+      />
+
+      <BaseModal isOpen={isSheetOpen} onClose={() => setSheetOpen(false)} variant="bottom">
+        <Wrapper>
+          <button>사진 등록하기</button>
+          <button>삭제하기</button>
+        </Wrapper>
+      </BaseModal>
+    </div>
+  );
+}
+
+const Wrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+`;

--- a/src/pages/Routes.tsx
+++ b/src/pages/Routes.tsx
@@ -11,6 +11,7 @@ import PendingApplicationPage from './PendingApplicationPage/Page';
 import AlarmPage from './Alarm/Page';
 import AttendPage from './Attend/Page';
 import CreateGroupPage from './CreateGroup/Page';
+import DemoPage from './DemoPage';
 //import { PrivateRoute } from '@/components/PrivateRoute';
 
 export const Routes = () => {
@@ -28,6 +29,7 @@ export const Routes = () => {
       <Route path={'/alarm'} element={<AlarmPage />} />
       <Route path={'/group/:groupId/attend'} element={<AttendPage />} />
       <Route path={'/create-group'} element={<CreateGroupPage />} />
+      <Route path={'/demo'} element={<DemoPage />} />
       {/* </Route> */}
       <Route path={'/login'} element={<LoginPage />} />
     </RouterRoutes>


### PR DESCRIPTION
## 주요 변경사항
신고모달을 구현하였습니다.
베이스 모달 공통 컴포넌트를 구현해서 바텀시트로도 사용할 수 있게 해놓았습니다.

## 리뷰어에게...
1. 바텀 시트 구현하신다고 하셔서 스타일같은거 중복될 것 같아서 일단 이렇게 만들어봤어요. 궁금한점 있거나 따로 하는게 낫다고 생각하면 의견주세요.

2. 신고하기 모달을 볼 수 있는 페이지가 없어서 임시로 demo라는 라우터에서 모달을 볼 수 있게 해놓았습니다. 테스트용으로 만들어 놨으니 추후 삭제하겠습니다.

3. 신고 관련해서 나중에는 다른 부분에서도 쓰일 것 같아서 커스텀 훅으로 분리하였습니다.

4. 모달 뜨는 것 때문에 베이스레이아웃 css를 일부 수정하였습니다.

## 관련 이슈

closes #49 
